### PR TITLE
Adds tree benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ We use Ubuntu 20.04 as the base image for building the systems.
 |--------------|-----------|-------------|
 | 1 | N-queens | Counts the number of solutions to the N queens problem for board size N x N |
 | 2 | Generator | Count the sum of elements in a complete binary tree using a generator |
+| 3 | Tree explore | Nondeterministically explore a complete binary tree with additional state |
 
 We use [hyperfine](https://github.com/sharkdp/hyperfine) to run the benchmarks.
 

--- a/benchmark_descriptions/003_tree.md
+++ b/benchmark_descriptions/003_tree.md
@@ -1,0 +1,80 @@
+# 003 - Tree
+
+The goal of this benchmark is to compute the maximal result of reducing a binary operation `op` over all possible paths from the root to the leaves in a full binary tree.
+Effect handlers are used to simulate non-determinism when exploring the tree.
+Leaf value is determined by the global state to benchmark the global state in presence of multiple resumptions.
+The initial value of the state is `0`.
+Before descending into a child subtree, the state is updated as `state := op state node_value`.
+The value of leaf is defined as the current value of the `state`.
+
+*Input* The program should take a single command line argument which is the height of the complete binary tree. For benchmarking the default input used is 16
+
+*Output* Maximal value of the fold operation over all paths from the root to leaves.
+
+The values in the binary tree nodes are defined in the same way as in [002_generator](./002_generator.md). If the height is 0,
+then the tree has no nodes. Hence, the output should be 0. If the tree has
+height `h`, then the root node has value `h`, all the nodes in the next level
+have value `h-1`, all the nodes in the subsequent level have value `h-2`, and so
+on.
+
+The binary tree should be constructed using a space-efficient DAG representation
+which represents complete binary tree of height `h` with `h` nodes. The OCaml
+function `make_tree` below constructs such a complete binary tree:
+
+```ocaml
+type 'a tree =
+| Leaf
+| Node of 'a tree * 'a * 'a tree
+
+let rec make_tree = function
+  | 0 -> Leaf
+  | n -> let t = make_tree (n-1) in Node (t,n,t)
+```
+
+The binary operation is defined as:
+
+```ocaml
+let op x y = (abs (x - 503*y + 37)) mod 1009
+```
+
+Tree should be explored in a depth-first manner. Left subtree should be explored before right subtree and `op` should be right reduced over the path. State should be updated in way such that every resumption of the continuation updates it.
+
+*Example*
+
+Tree of height `2` would produce the following possible paths:
+
+```ocaml
+[[2; 1; 503]; [2; 1; 37], [2; 1; 466]; [2; 1; 0]] 
+```
+
+with results:
+
+```ocaml
+[op 2 (op 1 503); op 2 (op 1 37); op 2 (op 1 466); op 2 (op 1 0)]
+- : [393; 858; 562; 913]
+```
+
+And the maximal value of `913`.
+
+Here are the solutions to the various input sizes:
+
+| Height | Maximal value |
+|--------|---------------|
+| 1  |  272 |
+| 2  |  913 |
+| 3  |  807 |
+| 4  |  953 |
+| 5  |  997 |
+| 6  | 1001 |
+| 7  |  978 |
+| 8  | 1008 |
+| 9  | 1006 |
+| 10 | 1003 |
+| 11 | 1002 |
+| 12 | 1002 |
+| 13 | 1003 |
+| 14 | 1006 |
+| 15 | 1003 |
+| 16 | 1008 |
+| 17 | 1007 |
+| 18 | 1008 |

--- a/benchmark_descriptions/003_tree.md
+++ b/benchmark_descriptions/003_tree.md
@@ -1,13 +1,15 @@
 # 003 - Tree
 
-The goal of this benchmark is to compute the maximal result of reducing a binary operation `op` over all possible paths from the root to the leaves in a full binary tree.
+The goal of this benchmark is to compute the maximal result of reducing a binary operation `op` over all possible paths from the root to the leaves in a full binary tree 10 times.
 Effect handlers are used to simulate non-determinism when exploring the tree.
 Leaf value is determined by the global state to benchmark the global state in presence of multiple resumptions.
+The global state can be implemented in a way that is most idiomatic for the target language.
 The initial value of the state is `0`.
 Before descending into a child subtree, the state is updated as `state := op state node_value`.
 The value of leaf is defined as the current value of the `state`.
+The full benchmark is repeated 10 times, each time, results from the previous traversal is taken as the initial value of the state.
 
-*Input* The program should take a single command line argument which is the height of the complete binary tree. For benchmarking the default input used is 16
+*Input* The program should take a single command line argument which is the height of the complete binary tree. For benchmarking the default input used is 16.
 
 *Output* Maximal value of the fold operation over all paths from the root to leaves.
 
@@ -60,21 +62,21 @@ Here are the solutions to the various input sizes:
 
 | Height | Maximal value |
 |--------|---------------|
-| 1  |  272 |
-| 2  |  913 |
-| 3  |  807 |
-| 4  |  953 |
-| 5  |  997 |
+| 1  |  147 |
+| 2  |  903 |
+| 3  |  923 |
+| 4  |  993 |
+| 5  |  946 |
 | 6  | 1001 |
-| 7  |  978 |
-| 8  | 1008 |
-| 9  | 1006 |
+| 7  |  981 |
+| 8  | 1006 |
+| 9  | 1003 |
 | 10 | 1003 |
-| 11 | 1002 |
+| 11 | 1004 |
 | 12 | 1002 |
 | 13 | 1003 |
 | 14 | 1006 |
 | 15 | 1003 |
-| 16 | 1008 |
+| 16 | 1005 |
 | 17 | 1007 |
 | 18 | 1008 |

--- a/benchmark_descriptions/003_tree.md
+++ b/benchmark_descriptions/003_tree.md
@@ -1,13 +1,16 @@
 # 003 - Tree
 
 The goal of this benchmark is to compute the maximal result of reducing a binary operation `op` over all possible paths from the root to the leaves in a full binary tree 10 times.
+The main idea of this benchmark is to analyze the performance of state in the presence of multiple resumptions.
+
 Effect handlers are used to simulate non-determinism when exploring the tree.
-Leaf value is determined by the global state to benchmark the global state in presence of multiple resumptions.
-The global state can be implemented in a way that is most idiomatic for the target language.
+Leaf value is determined by the global state.
 The initial value of the state is `0`.
 Before descending into a child subtree, the state is updated as `state := op state node_value`.
 The value of leaf is defined as the current value of the `state`.
-The full benchmark is repeated 10 times, each time, results from the previous traversal is taken as the initial value of the state.
+The global state can be implemented in a way which is most idiomatic for the target language.
+The full benchmark is repeated 10 times, each time, result from the previous traversal is taken as the initial value of the state.
+
 
 *Input* The program should take a single command line argument which is the height of the complete binary tree. For benchmarking the default input used is 16.
 

--- a/benchmarks/eff/Makefile
+++ b/benchmarks/eff/Makefile
@@ -2,11 +2,13 @@ all:
 	# Compile to ocaml
 	eff.exe --no-stdlib --compile-plain-ocaml benchmarks/001_nqueens/001_nqueens.eff | opam exec -- ocamlformat - --name=temp.ml --enable-outside-detected-project > benchmarks/001_nqueens/generated_001_nqueens.ml
 	eff.exe --no-stdlib --compile-plain-ocaml benchmarks/002_generator/002_generator.eff | opam exec -- ocamlformat - --name=temp.ml --enable-outside-detected-project > benchmarks/002_generator/generated_002_generator.ml
+	eff.exe --no-stdlib --compile-plain-ocaml benchmarks/003_tree_explore/003_tree_explore.eff | opam exec -- ocamlformat - --name=temp.ml --enable-outside-detected-project > benchmarks/003_tree_explore/generated_003_tree_explore.ml
 	# Build executables
 	opam exec -- dune build
 	hyperfine --export-csv eff.csv \
 		'./_build/default/benchmarks/001_nqueens/nqueens.exe 13' \
-		'./_build/default/benchmarks/002_generator/generator.exe 25'	 
+		'./_build/default/benchmarks/002_generator/generator.exe 25' \
+		'./_build/default/benchmarks/003_tree_explore/tree_explore.exe 16'	 
 	# Clean generated ocaml files
 	make -C . clean
 	# Move results to the root of the repository

--- a/benchmarks/eff/benchmarks/003_tree_explore/003_tree_explore.eff
+++ b/benchmarks/eff/benchmarks/003_tree_explore/003_tree_explore.eff
@@ -4,7 +4,7 @@ effect Get: unit -> int
 effect Set: int -> unit
 
 type tree
- = Empty
+ = Leaf
  | Node of tree * int * tree
 
 
@@ -18,7 +18,7 @@ let rec ( @ ) xs ys =
   | Cons (x, xs) -> Cons (x, xs @ ys)
 
 let rec make_tree = function
-  | 0 -> Empty
+  | 0 -> Leaf
   | n ->
     let t = make_tree (n - 1) in
     Node (t, n, t)
@@ -34,7 +34,7 @@ let max_path_merged_handler m =
   in
   let ___t = make_tree m in
   let rec explore t = match t with
-    | Empty -> perform (Get ())
+    | Leaf -> perform (Get ())
     | Node (left, x, right) -> 
       let next = if (perform (Choose ())) then left else right in
       let state = perform (Get ()) in
@@ -58,7 +58,15 @@ let max_path_merged_handler m =
         )
   )
   in
-  match ((with monad_state handle explore ___t) 0)
+  let rec looper s n = 
+    if n = 0 then 
+      s 
+    else (
+    let s = match ((with monad_state handle explore ___t) s)
     with (s', l) -> (
-    maxl 0 l
-  )
+      maxl 0 l
+    )  
+    in looper s (n - 1)
+    )
+  in
+  looper 0 10

--- a/benchmarks/eff/benchmarks/003_tree_explore/003_tree_explore.eff
+++ b/benchmarks/eff/benchmarks/003_tree_explore/003_tree_explore.eff
@@ -1,0 +1,64 @@
+
+effect Choose : unit -> bool
+effect Get: unit -> int
+effect Set: int -> unit
+
+type tree
+ = Empty
+ | Node of tree * int * tree
+
+
+let op x y = abs (x - (503 * y) + 37) mod 1009
+
+type intlist = Nil | Cons of (int * intlist)
+
+let rec ( @ ) xs ys =
+  match xs with
+  | Nil -> ys
+  | Cons (x, xs) -> Cons (x, xs @ ys)
+
+let rec make_tree = function
+  | 0 -> Empty
+  | n ->
+    let t = make_tree (n - 1) in
+    Node (t, n, t)
+
+let max a b = if a > b then a else b
+
+(* Eff is currently unable to automatically optimize nested handlers so we merge them by hand *)
+
+let max_path_merged_handler m = 
+  let rec maxl acc = function
+  | Nil -> acc
+  | Cons(x, xs) -> maxl (max x acc) xs
+  in
+  let ___t = make_tree m in
+  let rec explore t = match t with
+    | Empty -> perform (Get ())
+    | Node (left, x, right) -> 
+      let next = if (perform (Choose ())) then left else right in
+      let state = perform (Get ()) in
+      let q = op state x in
+      perform (Set q);
+      (op x (explore next))
+  in
+  let monad_state = handler
+  | y -> (fun u -> (u, Cons(y, Nil)))
+  | effect (Get ()) k -> (
+    fun s -> (k s) s
+    )
+  | effect (Set s) k -> (
+    fun _ -> (k ()) s
+  )
+  | effect (Choose ()) k -> (fun s -> 
+      match ((k true) s) with
+      | (s', l) ->
+        ( match ((k false) s') with
+          | (s', r) -> (s', l @ r)
+        )
+  )
+  in
+  match ((with monad_state handle explore ___t) 0)
+    with (s', l) -> (
+    maxl 0 l
+  )

--- a/benchmarks/eff/benchmarks/003_tree_explore/dune
+++ b/benchmarks/eff/benchmarks/003_tree_explore/dune
@@ -1,0 +1,5 @@
+(executable
+ (name tree_explore)
+ (libraries OcamlHeader)
+ (ocamlopt_flags
+  (:standard -O3)))

--- a/benchmarks/eff/benchmarks/003_tree_explore/tree_explore.ml
+++ b/benchmarks/eff/benchmarks/003_tree_explore/tree_explore.ml
@@ -1,0 +1,3 @@
+let n = try int_of_string Sys.argv.(1) with _ -> 16
+
+let _ = Printf.printf "%d\n" (Generated_003_tree_explore.max_path_merged_handler n)

--- a/benchmarks/ocaml/003_tree_explore/003_tree_explore.ml
+++ b/benchmarks/ocaml/003_tree_explore/003_tree_explore.ml
@@ -1,0 +1,44 @@
+effect Choose : unit -> bool
+
+let n = try int_of_string (Sys.argv.(1)) with _ -> 16
+
+let op x y = abs (x - (503 * y) + 37) mod 1009
+
+type 'a tree =
+| Leaf
+| Node of 'a tree * 'a * 'a tree
+
+let rec make = function
+  | 0 -> Leaf
+  | n -> let t = make (n-1) in Node (t,n,t)
+
+let main () =
+  let tree = make n in
+  let state = ref 0 in
+  let rec explore t = 
+    match t with 
+    | Leaf -> !state
+    | Node (l, s, r) ->
+      let next = if (perform (Choose ())) then l else r in
+      state := op !state s;
+      op s (explore next)
+  in
+  let rec looper n = 
+    if n = 0 then 
+      !state 
+    else (
+      let l = match (explore tree) with
+        | _x -> [_x]
+        | effect (Choose ()) k -> 
+          let l = continue (Obj.clone_continuation k) true in
+          let r = continue k false in
+          l @ r
+      in
+      let s = List.fold_left max 0 l in
+      state := s;
+      looper (n-1)
+    )
+  in
+  Printf.printf "%d\n" (looper 10)
+
+let _ = main ()

--- a/benchmarks/ocaml/003_tree_explore/dune
+++ b/benchmarks/ocaml/003_tree_explore/dune
@@ -1,0 +1,3 @@
+(executable
+  (name 003_tree_explore)
+	(ocamlopt_flags (:standard -O3)))

--- a/benchmarks/ocaml/Makefile
+++ b/benchmarks/ocaml/Makefile
@@ -4,7 +4,8 @@ all:
 	#Run OCaml benchmarks
 	hyperfine --export-csv ocaml.csv \
 		'./_build/default/001_nqueens/001_nqueens_ocaml.exe 13' \
-		'./_build/default/002_generator/002_generator_ocaml.exe 25'
+		'./_build/default/002_generator/002_generator_ocaml.exe 25' \
+		'./_build/default/003_tree_explore/003_tree_explore.exe 16'
 	#Cleanup
 	opam exec --switch=4.12.0+domains+effects -- dune clean
 	#Copy results to the root of the repository


### PR DESCRIPTION
I propose a new benchmark, currently implemented only in eff, but I also have multicore OCaml implementation from paper benchmarks, which can be shared and fixed if deemed unworthy.

The main idea of the benchmark is to test how the state (both read and update) is handled in the presence of
multiple resumptions. During the exploration of tree, the state is constantly updated. The formula for the update
is somewhat arbitrary, the main idea is to have a non-commutative, non-associative function
that does not commute with `max` so that native implementation can't do anything too smart.
Modular arithmetic is used to prevent any overflow issues, while `abs` is used to make it as portable as
possible (The behaviour of `mod` operator in Haskell and OCaml is different when the first argument is negative).


Would it be ok to explicitly say, that state does *not* need to be implemented as a handler, but in the most
optimal/idiomatic way for each language? Be it references, parametrized handlers... The purpose of this
benchmark is to test how "language native" state interacts with resumptions. Current eff implementation
uses handlers for the state as this is the most idiomatic way to implement state in eff.


The benchmark runs quite fast, but I am against using a lot bigger numbers as my native
implementation in OCaml quickly consumes the whole stack. Would it be sensible to mandate multiple (5-10)
runs of the exploration, each reusing the result of the previous run as initial state? This will make the benchmark a
lot less noisy and more accessible to multiple systems that rely heavily on function calls and might not be
able to cope with larger numbers.


I remember the talk about also providing a native implementation for benchmarks.
Would this mean a whole new system, in which language? But I think a reference native implementation in
benchmark description in a relatively known language (does not even need to be in the same language
for all benchmarks) would be a good idea. This will make it easier to test the code when preparing benchmarks, get a general idea of the implementation and what the problem is.