### PR TITLE
Benchmark template

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Inaugural chair (2021/07/23 - 2022/01/22): [Daniel Hillerström](https://github.
 If you wish to add a new benchmark `goat_benchmark` for system `awesome_system`,
 
 + Pick the next serial number for the benchmark `NNN`.
-+ Add the benchmark sources under `benchmarks/<awesome_system>/NNN_<goat_benchmark>`.
++ Add the benchmark sources under `benchmarks/<awesome_system>/NNN_<goat_benchmark>`, use the template provided in `benchmark_descriptions/000_template.md`.
 + Update the `Makefile` to build and run the benchmark.
 + Add a benchmark description under `benchmark_description/NNN_<goat_benchmark>.md`
   clearly stating the input, output and the expectation from the benchmark. Make sure

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If you wish to add a new benchmark `goat_benchmark` for system `awesome_system`,
 + Add a benchmark description under `benchmark_description/NNN_<goat_benchmark>.md`
   clearly stating the input, output and the expectation from the benchmark. Make sure
   you mention the default input argument for the benchmark.
-+ Update this `README.md` file to add the new benchmark to the table of benchmarks.
++ Update this `README.md` file to add the new benchmark to the table of benchmarks and to the benchmark availability table.
 
 If you wish to add a benchmark `leet_benchmark` that is not available for a system
 `awesome_system` but is available for another system
@@ -98,7 +98,7 @@ If you wish to contribute a system `awesome_system`, please
 + create a status badge for the new workflow and add it to the top of this `README.md` file in
   lexicographic order.
 
-Ideally, you will also add benchmarks to go with the new system.
+Ideally, you will also add benchmarks to go with the new system and update the benchmark avaialability table.
 
 Having a dockerfile aids reproducibility and ensures that we can build the system from
 scratch natively on a machine if needed. The benchmarking chair will push the image

--- a/benchmark_descriptions/000_template.md
+++ b/benchmark_descriptions/000_template.md
@@ -1,50 +1,53 @@
 # XXX - Short benchmark name
 
-Short description of the benchmark in a few sentences.
+*Short description of the benchmark in a few sentences.*
 
 ## Input
 
-Describe the type and shape of the input data.
+*Describe the type and shape of the input data.
 Explicitly state default input to be used in the absence of input argument.
-The default input value should be reasonably small so that benchmarks can be computed in a reasonable time (up to a few seconds).
+The default input value should be reasonably small so that benchmarks can be computed in a reasonable time (up to a few seconds).*
 
 ## Output
 
-Describe the type and shape of the output data. Prefer to use simple and small output that makes correctness testing easier.
+*Describe the type and shape of the output data. Prefer to use simple and small output that makes correctness testing easier.*
 
 ## Description
 
-A longer and more detailed description of the benchmark.
+*A longer and more detailed description of the benchmark.*
 
-Clearly describe the algorithm of the benchmark and provide a small example if possible.
-If the benchmark relies on more complicated input generated from input value (binary tree, random graph, ...), provide a code sample that generates it from the input parameters.
+*Clearly describe the algorithm of the benchmark and provide a small example if possible.
+If the benchmark relies on more complicated input generated from input value (binary tree, random graph, ...), provide a code sample that generates it from the input parameters.*
 
-If a specific version of an algorithm is used, provide a detailed description and possible code sample to explain how it should be implemented.
+*If a specific version of an algorithm is used, provide a detailed description and possible code sample to explain how it should be implemented.*
 
-Default benchmark size should target a runtime between a second and up to a few seconds.
+*Default benchmark size should target a runtime between a second and up to a few seconds.
 If the generation of input data is time-consuming, it is ok to run the benchmark multiple times on the same generated input for more accurate results.
-Be careful that a smart compiler will not optimize the multiple runs away and clearly state the number of times the computation should be repeated.
+Be careful that a smart compiler will not optimize the multiple runs away and clearly state the number of times the computation should be repeated.*
 
 ## Sample explanation (optional)
 
-Optional explanation of benchmark computation on small sample input.
+*Optional explanation of benchmark computation on small sample input.*
 
 ## Benchmark rationale (optional)
 
-Provide a short rationale for the benchmark.
-Describe what it measures and why it is important to measure it.
+*Provide a short rationale for the benchmark.
+Describe what it measures and why it is important to measure it.*
 
+Example:
 This benchmark measures the performance of deeply nested handlers.
 This is a good benchmark to measure the performance of selecting the correct handler for performed effect.
 
 ## Reference (optional)
 
-If necessary, provide a reference.
+*If necessary, provide a reference.*
 
 ## Output example
 
-Provide a larger set of input and output data that can be used to verify the correctness of the implementation.
-Provide a reasonable range of output parameters and comment on the expected range that should be computed in a reasonable time.
+*Provide a larger set of input and output data that can be used to verify the correctness of the implementation.
+Provide a reasonable range of output parameters and comment on the expected range that should be computed in a reasonable time.*
+
+Example:
 
 | Input param | Square of the input |
 |--------|---------------------|

--- a/benchmark_descriptions/000_template.md
+++ b/benchmark_descriptions/000_template.md
@@ -29,14 +29,6 @@ Make sure, that smart compiler will not optimize the multiple runs away and clea
 
 Optional explanation of benchmark computation on small sample input.
 
-## Labels (optional)
-
-Labels corresponding to the benchmark (multiple).
-Use labels provided in [LABELS.md](../LABELS.md).
-If suitable labels are not available, you may create your own and put them in the LABELS.md file.
-
-MULTIPLE_RESUMPTIONS, DEEP_HANDLER_STACK, GENERATORS
-
 ## Benchmark rationale (optional)
 
 Provide a short rationale for the benchmark.

--- a/benchmark_descriptions/000_template.md
+++ b/benchmark_descriptions/000_template.md
@@ -1,0 +1,72 @@
+# XXX - Short benchmark name
+
+Short description of the benchmark in a few sentences.
+
+## Input
+
+Describe the type and shape of the input data.
+Explicitly state default input to be used in the absence of input argument.
+The default input value should be reasonably small so that benchmarks can be computed in a reasonable time (up to a few seconds).
+
+## Output
+
+Describe the type and shape of the output data. Prefer to use simple and small output that makes correctness testing easier.
+
+## Description
+
+A longer and more detailed description of the benchmark.
+
+Clearly describe the algorithm of the benchmark and provide a small example if possible.
+If the benchmark relies on more complicated input generated from input value (binary tree, random graph, ...), provide a code sample that generates it from the input parameters.
+
+If a specific version of an algorithm is used, provide a detailed description and possible code sample to explain how it should be implemented.
+
+Default benchmark size should target a runtime between a second and up to a few seconds.
+If the generation of input data is time-consuming, it is ok to run the benchmark multiple times on the same generated input for more accurate results.
+Make sure, that smart compiler will not optimize the multiple runs away and clearly state the number of times the computation should be repeated.
+
+## Sample explanation (optional)
+
+Optional explanation of benchmark computation on small sample input.
+
+## Labels (optional)
+
+Labels corresponding to the benchmark (multiple).
+Use labels provided in [LABELS.md](../LABELS.md).
+If suitable labels are not available, you may create your own and put them in the LABELS.md file.
+
+MULTIPLE_RESUMPTIONS, DEEP_HANDLER_STACK, GENERATORS
+
+## Benchmark rationale (optional)
+
+Provide a short rationale for the benchmark.
+Describe what it measures and why it is important to measure it.
+
+This benchmark measures the performance of deeply nested handlers.
+This is a good benchmark to measure the performance of selecting the correct handler for performed effect.
+
+## Reference (optional)
+
+If necessary, provide a reference.
+
+## Output example
+
+Provide a larger set of input and output data that can be used to verify the correctness of the implementation.
+Provide a reasonable range of output parameters and comment on the expected range that should be computed in a reasonable time.
+
+| Input param | Square of the input |
+|--------|---------------------|
+| 0 | 0 |
+| 1 | 1 |
+| 2 | 4 |
+| 3 | 9 |
+| 4 | 16 |
+| 5 | 25 |
+| 6 | 36 |
+| 7 | 49 |
+| 8 | 64 |
+| 9 | 81 |
+| 10 | 100 |
+| 11 | 121 |
+| 12 | 144 |
+| 13 | 169 |

--- a/benchmark_descriptions/000_template.md
+++ b/benchmark_descriptions/000_template.md
@@ -23,7 +23,7 @@ If a specific version of an algorithm is used, provide a detailed description an
 
 Default benchmark size should target a runtime between a second and up to a few seconds.
 If the generation of input data is time-consuming, it is ok to run the benchmark multiple times on the same generated input for more accurate results.
-Make sure, that smart compiler will not optimize the multiple runs away and clearly state the number of times the computation should be repeated.
+Be careful that a smart compiler will not optimize the multiple runs away and clearly state the number of times the computation should be repeated.
 
 ## Sample explanation (optional)
 

--- a/benchmark_descriptions/001_nqueens.md
+++ b/benchmark_descriptions/001_nqueens.md
@@ -4,13 +4,24 @@ The goal of the benchmark is to calculate the number of safe assignments of
 queens on a N x N chess board. Effect handlers are utilised for backtracking
 search.
 
-**Input:** The program should take a single commandline argument which is the
+## Input
+
+The program should take a single command-line argument which is the
 size `N` of the chess board. For benchmarking, the default input used is 13.
 
-**Output:** The program should print the number of solutions to the standard
+## Output
+
+The program should print the number of solutions to the standard
 output.
 
-Here are the solutions to the various input sizes:
+## Description
+
+Compute the number of solutions to the N-Queens problem.
+Use brute force search without any heuristics or symmetries to speed up the search.
+The suggested implementation of backtracking is to use the effect `Choose : int -> int`
+which continues the search for every cell in the current column.
+
+## Output example
 
 | N | Number of solutions |
 |---|---------------------|

--- a/benchmark_descriptions/002_generator.md
+++ b/benchmark_descriptions/002_generator.md
@@ -4,11 +4,20 @@ The goal of the benchmark is to compute the sum of the elements in a complete
 binary tree of height `h` using a generator. The generator is implemented using
 effect handlers.
 
-**Input:** The program should take a single commandline argument which is the
+## Input
+
+The program should take a single command-line argument which is the
 height of the complete binary tree. For benchmarking, the default input used is
 25.
 
-**Output:** The sum of the elements in the binary tree.
+## Output
+
+The sum of the elements in the binary tree.
+
+## Description
+
+Binary tree should be explored in a depth-first fashion, exploring the left subtree,
+yielding the value of the node, and then exploring the right subtree.
 
 The values in the binary tree nodes are defined as follows. If the height is 0,
 then the tree has no nodes. Hence, the output should be 0. If the tree has
@@ -30,7 +39,7 @@ let rec make_tree = function
   | n -> let t = make_tree (n-1) in Node (t,n,t)
 ```
 
-Here are the solutions to the various input sizes:
+## Output example
 
 | Height | Sum of the elements |
 |--------|---------------------|

--- a/benchmark_descriptions/003_tree.md
+++ b/benchmark_descriptions/003_tree.md
@@ -1,7 +1,16 @@
 # 003 - Tree
 
 The goal of this benchmark is to compute the maximal result of reducing a binary operation `op` over all possible paths from the root to the leaves in a full binary tree 10 times.
-The main idea of this benchmark is to analyze the performance of state in the presence of multiple resumptions.
+
+## Input
+
+The program should take a single command-line argument which is the height of the complete binary tree. For benchmarking the default input used is 16.
+
+## Output
+
+Maximal value of the fold operation over all paths from the root to leaves.
+
+## Description
 
 Effect handlers are used to simulate non-determinism when exploring the tree.
 Leaf value is determined by the global state.
@@ -11,10 +20,8 @@ The value of leaf is defined as the current value of the `state`.
 The global state can be implemented in a way which is most idiomatic for the target language.
 The full benchmark is repeated 10 times, each time, result from the previous traversal is taken as the initial value of the state.
 
-
-*Input* The program should take a single command line argument which is the height of the complete binary tree. For benchmarking the default input used is 16.
-
-*Output* Maximal value of the fold operation over all paths from the root to leaves.
+Tree should be explored in a depth-first manner. Left subtree should be explored before right subtree and `op`
+should be right reduced over the path. State should be updated in way such that every resumption of the continuation updates it.
 
 The values in the binary tree nodes are defined in the same way as in [002_generator](./002_generator.md). If the height is 0,
 then the tree has no nodes. Hence, the output should be 0. If the tree has
@@ -42,9 +49,7 @@ The binary operation is defined as:
 let op x y = (abs (x - 503*y + 37)) mod 1009
 ```
 
-Tree should be explored in a depth-first manner. Left subtree should be explored before right subtree and `op` should be right reduced over the path. State should be updated in way such that every resumption of the continuation updates it.
-
-*Example*
+## Sample explanation
 
 Tree of height `2` would produce the following possible paths:
 
@@ -61,7 +66,11 @@ with results:
 
 And the maximal value of `913`.
 
-Here are the solutions to the various input sizes:
+## Benchmark rationale
+
+The rationale of this benchmark is to analyze the performance of state in the presence of multiple resumptions.
+
+## Output example
 
 | Height | Maximal value |
 |--------|---------------|


### PR DESCRIPTION
I added a benchmark template that includes a bit more optional information. Additional information should make it easier to analyze and interpret benchmarks and a template should make it easier to add new benchmarks in a more uniform manner. 

The formatting is changed to allow for more subsections. If you are ok with this change I'll update the existing benchmarks to conform to this structure in the same pull request. 