### PR TITLE
Adds labels

### DIFF
--- a/LABELS.md
+++ b/LABELS.md
@@ -1,0 +1,17 @@
+# Labels
+
+## BACKTRACKING
+
+Handlers are used to simulate backtracking in a searching algorithm.
+
+## CONCURRENCY
+
+Handlers are used to simulate concurrency.
+
+## ESCAPING_CONTINUATION
+
+Continuation is wrapped and is executed outside of the original handler.
+
+## MULTIPLE_RESUMPTIONS
+
+Captured continuations are resumed multiple times.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Legend:
   - `sys_<system_name>`: Builds the `<system_name>` docker image.
   - `bench_<system_name>`: Runs the benchmarks using the docker image for the
     `<system_name>`.
++ `LABELS.md` contains a list of available benchmark labels.
+  Each benchmark can be assigned multiple labels.
 
 ## Contributing
 

--- a/benchmark_descriptions/000_template.md
+++ b/benchmark_descriptions/000_template.md
@@ -42,6 +42,14 @@ This is a good benchmark to measure the performance of selecting the correct han
 
 *If necessary, provide a reference.*
 
+## Labels (optional)
+
+*Optional labels to help categorize the benchmark.
+If currently available labels in `../LABLES.md` do not sufficiently capture the classification, you are welcome to add new ones.*
+
+Example:
+MULTIPLE_RESUMPTIONS, CONCURRENCY, MULTIPLE_RESUMPTIONS
+
 ## Output example
 
 *Provide a larger set of input and output data that can be used to verify the correctness of the implementation.

--- a/benchmark_descriptions/000_template.md
+++ b/benchmark_descriptions/000_template.md
@@ -45,7 +45,8 @@ This is a good benchmark to measure the performance of selecting the correct han
 ## Labels (optional)
 
 *Optional labels to help categorize the benchmark.
-If currently available labels in `../LABLES.md` do not sufficiently capture the classification, you are welcome to add new ones.*
+If currently available labels in `../LABLES.md` do not sufficiently capture the classification, you are welcome to add new ones.
+If you do add a new label, be sure to add it to applicable existing benchmarks.*
 
 Example:
 MULTIPLE_RESUMPTIONS, CONCURRENCY, MULTIPLE_RESUMPTIONS

--- a/benchmark_descriptions/001_nqueens.md
+++ b/benchmark_descriptions/001_nqueens.md
@@ -14,6 +14,10 @@ size `N` of the chess board. For benchmarking, the default input used is 13.
 The program should print the number of solutions to the standard
 output.
 
+## Labels
+
+BACKTRACKING, MULTIPLE_RESUMPTIONS
+
 ## Description
 
 Compute the number of solutions to the N-Queens problem.

--- a/benchmark_descriptions/002_generator.md
+++ b/benchmark_descriptions/002_generator.md
@@ -39,6 +39,10 @@ let rec make_tree = function
   | n -> let t = make_tree (n-1) in Node (t,n,t)
 ```
 
+## Labels
+
+ESCAPING_CONTINUATION
+
 ## Output example
 
 | Height | Sum of the elements |

--- a/benchmark_descriptions/003_tree.md
+++ b/benchmark_descriptions/003_tree.md
@@ -70,6 +70,10 @@ And the maximal value of `913`.
 
 The rationale of this benchmark is to analyze the performance of state in the presence of multiple resumptions.
 
+## Labels
+
+BACKTRACKING, MULTIPLE_RESUMPTIONS
+
 ## Output example
 
 | Height | Maximal value |


### PR DESCRIPTION
This is more of a proposal and open to debate.

It would be nice to have some sort of label system when the benchmark set grows. To be able to more quickly filter through interesting ones, find desired test cases. One useful case is to have a label for "problematic" benchmarks that are tricky to implement correctly (non-scoped or evil handlers could be an example). 

This is a simple idea so any changes, rejections, new and better labels..., are welcome.