### PR TITLE
Libmpeff first benchmarks

### DIFF
--- a/benchmarks/libmpeff/Makefile
+++ b/benchmarks/libmpeff/Makefile
@@ -2,13 +2,13 @@ LIBMPEFF     := /home/ubuntu/libmprompt
 LIBMPEFF_H   := $(LIBMPEFF)/include
 LIBMPEFF_LIB := $(LIBMPEFF)/out/release
 
-CC               := gcc
-CC_COMPILE_FLAGS := -std=gnu99 -O3 -I$(LIBMPEFF_H)
+CC               := clang-14
+CC_COMPILE_FLAGS := -std=gnu99 -O3 -I$(LIBMPEFF_H) -flto
 CC_WARN_FLAGS    := -Wall -Wextra \
 									  -Wformat=2 -Wno-unused-parameter -Wshadow \
 										-Wwrite-strings \
 										-Wredundant-decls -Wnested-externs -Wmissing-include-dirs
-CC_LINK_FLAGS    := -std=gnu99 -O3
+CC_LINK_FLAGS    := -std=gnu99 -O3 -flto
 
 LD_FLAGS   := -l:libmpeff.a -l:libmprompt.a -L$(LIBMPEFF_LIB)
 

--- a/benchmarks/libmpeff/Makefile
+++ b/benchmarks/libmpeff/Makefile
@@ -1,2 +1,56 @@
-test:
-	# TODO
+LIBMPEFF     := /home/ubuntu/libmprompt
+LIBMPEFF_H   := $(LIBMPEFF)/include
+LIBMPEFF_LIB := $(LIBMPEFF)/out/release
+
+CC               := gcc
+CC_COMPILE_FLAGS := -std=gnu99 -O3 -I$(LIBMPEFF_H)
+CC_WARN_FLAGS    := -Wall -Wextra \
+									  -Wformat=2 -Wno-unused-parameter -Wshadow \
+										-Wwrite-strings \
+										-Wredundant-decls -Wnested-externs -Wmissing-include-dirs
+CC_LINK_FLAGS    := -std=gnu99 -O3
+
+LD_FLAGS   := -l:libmpeff.a -l:libmprompt.a -L$(LIBMPEFF_LIB)
+
+compile_cmd = $(CC)	$(CC_COMPILE_FLAGS) $(CC_WARN_FLAGS) -o main.o -c main.c
+link_cmd    = $(CC) $(CC_LINK_FLAGS) -o main main.o $(LD_FLAGS)
+build_cmd   = cd $(1) ; $(call compile_cmd, $(1)); $(call link_cmd, $(1))
+test_cmd    = cd $(1) ; ./main $(2) > actual ; echo $(3) > expected ; diff expected actual
+
+bench: build
+	hyperfine --export-csv results.csv \
+					'./countdown/main 200000000' \
+					'./fibonacci_recursive/main 42' \
+					'./product_early/main 100000' \
+					'./iterator/main 40000000' \
+					'./generator/main 25' \
+					'./parsing_dollars/main 20000' \
+					'./resume_nontail/main 20000' \
+					'./handler_sieve/main 60000'
+
+test: build
+	$(call test_cmd, countdown, 5, 0)
+	$(call test_cmd, fibonacci_recursive, 5, 5)
+	$(call test_cmd, product_early, 5, 0)
+	$(call test_cmd, iterator, 5, 15)
+	$(call test_cmd, generator, 5, 57)
+	$(call test_cmd, parsing_dollars, 10, 55)
+	$(call test_cmd, resume_nontail, 5, 37)
+	$(call test_cmd, handler_sieve, 10, 17)
+
+build: 
+	$(call build_cmd, countdown)
+	$(call build_cmd, fibonacci_recursive)
+	$(call build_cmd, product_early)
+	$(call build_cmd, iterator)
+	$(call build_cmd, generator)
+	$(call build_cmd, parsing_dollars)
+	$(call build_cmd, resume_nontail)
+	$(call build_cmd, handler_sieve)
+
+clean:
+	-rm */main
+	-rm */expected
+	-rm */actual
+	-rm */*.o
+	-rm */*.out

--- a/benchmarks/libmpeff/countdown/main.c
+++ b/benchmarks/libmpeff/countdown/main.c
@@ -1,0 +1,37 @@
+#include "mpeff.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+MPE_DEFINE_EFFECT2(state, get, put)
+MPE_DEFINE_OP0(state, get, long)
+MPE_DEFINE_VOIDOP1(state, put, long)
+
+static void* _state_get(mpe_resume_t* r, void* local, void* arg) {
+  return mpe_resume_tail(r, local, local);
+}
+
+static void* _state_put(mpe_resume_t* r, void* local, void* arg) {
+  return mpe_resume_tail(r, arg, NULL);
+}
+
+static const mpe_handlerdef_t state_hdef = { MPE_EFFECT(state), NULL, {
+  { MPE_OP_TAIL_NOOP, MPE_OPTAG(state,get), &_state_get },
+  { MPE_OP_TAIL_NOOP, MPE_OPTAG(state,put), &_state_put },
+  { MPE_OP_NULL, mpe_op_null, NULL }
+}};
+
+static void* countdown(void* parameter) {
+  long state = state_get();
+  while (state > 0) {
+    state_put(state - 1);
+    state = state_get();
+  }
+  return mpe_voidp_long(state);
+}
+
+int main(int argc, char** argv) { 
+  int64_t n = argc != 2 ? 5 : atoi(argv[1]);
+  int64_t result = mpe_long_voidp(mpe_handle(&state_hdef, mpe_voidp_long(n), &countdown, NULL));
+  printf("%ld\n", result);
+  return 0;   
+}

--- a/benchmarks/libmpeff/fibonacci_recursive/main.c
+++ b/benchmarks/libmpeff/fibonacci_recursive/main.c
@@ -1,0 +1,20 @@
+#include "mpeff.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+int64_t fib(int n) {
+  if (n == 0) return 0;
+  if (n == 1) return 1;
+  return fib(n - 1) + fib(n - 2);
+}
+
+int main(int argc, char** argv) {
+  int64_t n = argc != 2 ? 5 : atoi(argv[1]);
+  int64_t result = fib(n);
+
+  // Increase output buffer size to increase performance
+  char buffer[8192];
+  setvbuf(stdout, buffer, _IOFBF, sizeof(buffer));
+  printf("%ld\n", result);
+  return 0;
+}

--- a/benchmarks/libmpeff/generator/main.c
+++ b/benchmarks/libmpeff/generator/main.c
@@ -1,0 +1,122 @@
+#include "mpeff.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+MPE_DEFINE_EFFECT1(yield, yield)
+MPE_DEFINE_VOIDOP1(yield, yield, long)
+
+// Tree data structure
+struct node_t {
+  struct node_t* l;
+  int64_t v;
+  struct node_t* r;
+};
+typedef struct node_t node_t;
+typedef struct node_t* tree_t;
+
+// Allocate and free a tree node
+static inline node_t* alloc_node() { return malloc(sizeof(node_t));}
+static inline void free_node(node_t* node) { free(node); }
+
+// Generator data structure
+struct thunk_t {
+  int64_t v;
+  mpe_resume_t *k;
+};
+typedef struct thunk_t thunk_t;
+typedef thunk_t generator_t;
+
+// Allocate and free a thunk
+static inline thunk_t* alloc_thunk() { return malloc(sizeof(thunk_t));}
+static inline void free_thunk(thunk_t* thunk) { free(thunk); }
+
+// Allocate a tree on the heap
+static tree_t makeTree(int n) {
+  if (n == 0) return NULL;
+  tree_t node = alloc_node();
+  tree_t t = makeTree (n - 1);
+
+  // Note: both left and right pointers point to the same memory, 
+  // to match the other languages
+  node->l = t;
+  node->r = t;
+  node->v = n;
+  return node;
+}
+
+// Free tree from heap
+static void free_tree(tree_t tree) {
+  if (tree == NULL) return;
+  free_tree(tree->l);
+  free_node(tree);
+}
+
+static void* handler_yield(mpe_resume_t* r, void* local, void* arg) {
+  thunk_t* thunk = alloc_thunk(); 
+  thunk->v = mpe_long_voidp(arg);
+  thunk->k = r;
+  return mpe_voidp_ptr(thunk); 
+}
+
+static void* handler_result(void* local, void* arg) {
+  thunk_t* thunk = alloc_thunk();
+  thunk->v = mpe_long_voidp(arg);
+  thunk->k = NULL;
+  return mpe_voidp_ptr(thunk);
+}
+
+static const mpe_handlerdef_t yield_hdef = { 
+  MPE_EFFECT(yield), &handler_result, {
+  { MPE_OP_ONCE, MPE_OPTAG(yield,yield), &handler_yield },
+  { MPE_OP_NULL, mpe_op_null, NULL }
+}};
+
+static inline thunk_t* resume_yield(thunk_t* t) {
+  mpe_resume_t* k = t->k;
+  free_thunk(t);
+  return (thunk_t*) mpe_resume(k, NULL, NULL);
+}
+
+// Performs yield for every node in tree
+static void* iterate(void* parameter) {
+  if (parameter == NULL) return NULL;
+  tree_t tree = parameter;
+  iterate(tree->l);
+  yield_yield(tree->v);
+  iterate(tree->r);
+  return NULL;
+}
+
+// Sums all values generated
+static int64_t sum(generator_t* generator) {
+  int64_t acc = 0;
+  while (generator->k != NULL) {
+    acc += generator->v;
+    generator = resume_yield(generator);
+  }
+  free_thunk(generator);
+  return acc;
+}
+
+static int64_t run(int64_t n) {
+  tree_t tree = makeTree(n); 
+  generator_t* generator = mpe_handle(&yield_hdef, NULL, &iterate, tree);
+
+  // Sum generated values
+  int64_t result = sum(generator);
+
+  // Free memory
+  free_tree(tree);
+  return result;
+}
+
+int main(int argc, char** argv) { 
+  int64_t n = argc != 2 ? 25 : atoi(argv[1]);
+  int64_t r = run(n);
+
+  // Increase size of output buffer for performance
+  char buffer[8192];
+  setvbuf(stdout, buffer, _IOFBF, sizeof(buffer));
+  printf("%ld\n", r);
+  return 0; 
+}

--- a/benchmarks/libmpeff/handler_sieve/main.c
+++ b/benchmarks/libmpeff/handler_sieve/main.c
@@ -15,11 +15,11 @@ static void* handle_sieve_prime(mpe_resume_t* r, void* local, void* arg) {
   bool res;
   if (mpe_long_voidp(arg) % mpe_long_voidp(local) == 0) res = false;
   else res = mpe_bool_voidp(sieve_prime(mpe_long_voidp(arg)));
-  return mpe_resume(r, local, mpe_voidp_bool(res));
+  return mpe_resume_tail(r, local, mpe_voidp_bool(res));
 }
 
 static void* handle_top_sieve_prime(mpe_resume_t* r, void* local, void* arg) {
-  return mpe_resume(r, local, mpe_voidp_bool(true));
+  return mpe_resume_tail(r, local, mpe_voidp_bool(true));
 }
 
 static const mpe_handlerdef_t sieve_hdef = {

--- a/benchmarks/libmpeff/handler_sieve/main.c
+++ b/benchmarks/libmpeff/handler_sieve/main.c
@@ -1,0 +1,86 @@
+#include "mpeff.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+MPE_DEFINE_EFFECT1(sieve, prime)
+MPE_DEFINE_OP1(sieve, prime, bool, long)
+
+typedef struct primes_params_t {
+  int64_t i;
+  int64_t n;
+  int64_t a;
+} primes_params_t;
+
+static void* handle_sieve_prime(mpe_resume_t* r, void* local, void* arg) {
+  bool res;
+  if (mpe_long_voidp(arg) % mpe_long_voidp(local) == 0) res = false;
+  else {
+    printf("Performing PRIME(%ld) when local = %ld.\n", mpe_long_voidp(arg), mpe_long_voidp(local));
+    res = mpe_bool_voidp(sieve_prime(mpe_long_voidp(arg)));
+  }
+  return mpe_resume_tail(r, local, mpe_voidp_bool(res));
+}
+
+static void* handle_top_sieve_prime(mpe_resume_t* r, void* local, void* arg) {
+  return mpe_resume_tail(r, local, mpe_voidp_bool(true));
+}
+
+static const mpe_handlerdef_t sieve_hdef = {
+  MPE_EFFECT(sieve), NULL,
+  {  
+    { MPE_OP_TAIL, MPE_OPTAG(sieve,prime), &handle_sieve_prime },
+    { MPE_OP_NULL, mpe_op_null, NULL }
+  } 
+};
+
+static const mpe_handlerdef_t top_sieve_hdef = {
+  MPE_EFFECT(sieve), NULL,
+  {  
+    { MPE_OP_TAIL, MPE_OPTAG(sieve,prime), &handle_top_sieve_prime },
+    { MPE_OP_NULL, mpe_op_null, NULL }
+  } 
+};
+
+static void* primes(void* parameter) {
+  primes_params_t* params = (primes_params_t*) mpe_voidp_ptr(parameter);
+  if (params->i >= params->n) return mpe_voidp_long(params->a);
+
+  int64_t i = params->i;
+  printf("Performing PRIME(%ld) [in-func].\n", params->i);
+  if (sieve_prime(params->i)) {
+    params->a += i;
+    params->i++;
+    printf("-{ Installing handler for %ld }-\n", i);
+    return mpe_handle(&sieve_hdef, 
+                     mpe_voidp_long(i), 
+                     &primes, 
+                     mpe_voidp_ptr(params));
+  }
+  else {
+    params->i++;
+    return primes(mpe_voidp_ptr(params));
+  }
+}
+
+static int64_t run(int64_t n) {
+  primes_params_t params = {
+    .i = 2,
+    .n = n,
+    .a = 0
+  };
+  return mpe_long_voidp(mpe_handle(&top_sieve_hdef, 
+                                 NULL, 
+                                 &primes, 
+                                 mpe_voidp_ptr(&params)));
+}
+
+int main(int argc, char** argv) { 
+  int64_t n = argc != 2 ? 10 : atoi(argv[1]);
+  int64_t r = run(n);
+
+  // Increase output buffer size to increase performance
+  char buffer[8192];
+  setvbuf(stdout, buffer, _IOFBF, sizeof(buffer));
+  printf("%ld\n", r);
+  return 0;   
+}

--- a/benchmarks/libmpeff/handler_sieve/main.c
+++ b/benchmarks/libmpeff/handler_sieve/main.c
@@ -14,21 +14,18 @@ typedef struct primes_params_t {
 static void* handle_sieve_prime(mpe_resume_t* r, void* local, void* arg) {
   bool res;
   if (mpe_long_voidp(arg) % mpe_long_voidp(local) == 0) res = false;
-  else {
-    printf("Performing PRIME(%ld) when local = %ld.\n", mpe_long_voidp(arg), mpe_long_voidp(local));
-    res = mpe_bool_voidp(sieve_prime(mpe_long_voidp(arg)));
-  }
-  return mpe_resume_tail(r, local, mpe_voidp_bool(res));
+  else res = mpe_bool_voidp(sieve_prime(mpe_long_voidp(arg)));
+  return mpe_resume(r, local, mpe_voidp_bool(res));
 }
 
 static void* handle_top_sieve_prime(mpe_resume_t* r, void* local, void* arg) {
-  return mpe_resume_tail(r, local, mpe_voidp_bool(true));
+  return mpe_resume(r, local, mpe_voidp_bool(true));
 }
 
 static const mpe_handlerdef_t sieve_hdef = {
   MPE_EFFECT(sieve), NULL,
   {  
-    { MPE_OP_TAIL, MPE_OPTAG(sieve,prime), &handle_sieve_prime },
+    { MPE_OP_SCOPED_ONCE, MPE_OPTAG(sieve,prime), &handle_sieve_prime },
     { MPE_OP_NULL, mpe_op_null, NULL }
   } 
 };
@@ -36,7 +33,7 @@ static const mpe_handlerdef_t sieve_hdef = {
 static const mpe_handlerdef_t top_sieve_hdef = {
   MPE_EFFECT(sieve), NULL,
   {  
-    { MPE_OP_TAIL, MPE_OPTAG(sieve,prime), &handle_top_sieve_prime },
+    { MPE_OP_SCOPED_ONCE, MPE_OPTAG(sieve,prime), &handle_top_sieve_prime },
     { MPE_OP_NULL, mpe_op_null, NULL }
   } 
 };
@@ -46,11 +43,9 @@ static void* primes(void* parameter) {
   if (params->i >= params->n) return mpe_voidp_long(params->a);
 
   int64_t i = params->i;
-  printf("Performing PRIME(%ld) [in-func].\n", params->i);
   if (sieve_prime(params->i)) {
     params->a += i;
     params->i++;
-    printf("-{ Installing handler for %ld }-\n", i);
     return mpe_handle(&sieve_hdef, 
                      mpe_voidp_long(i), 
                      &primes, 
@@ -68,10 +63,9 @@ static int64_t run(int64_t n) {
     .n = n,
     .a = 0
   };
-  return mpe_long_voidp(mpe_handle(&top_sieve_hdef, 
-                                 NULL, 
-                                 &primes, 
-                                 mpe_voidp_ptr(&params)));
+  return mpe_long_voidp(
+    mpe_handle(&top_sieve_hdef, NULL, &primes, mpe_voidp_ptr(&params))
+  );
 }
 
 int main(int argc, char** argv) { 

--- a/benchmarks/libmpeff/iterator/main.c
+++ b/benchmarks/libmpeff/iterator/main.c
@@ -1,0 +1,59 @@
+#include "mpeff.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+MPE_DEFINE_EFFECT1(iterator, emit);
+MPE_DEFINE_VOIDOP1(iterator, emit, long);
+
+static void* handle_iterator_emit(mpe_resume_t* r, void* local, void* arg) {
+  long result = mpe_long_voidp(local) + mpe_long_voidp(arg);
+  return mpe_resume_tail(r, mpe_voidp_long(result), NULL);
+}
+
+static void* handle_iterator_result(void* local, void* arg) {
+  return local;
+}
+
+static const mpe_handlerdef_t iterator_hdef = { 
+  MPE_EFFECT(iterator), 
+  &handle_iterator_result, 
+  {
+    { MPE_OP_TAIL_NOOP, MPE_OPTAG(iterator,emit), &handle_iterator_emit },
+    { MPE_OP_NULL, mpe_op_null, NULL }
+  }
+};
+
+struct range_args {
+  int64_t l;
+  int64_t u;
+};
+
+static void* range(void* args) {
+  struct range_args* range_args = mpe_ptr_voidp(args);
+  for (int l = range_args->l; l <= range_args->u; l++) {
+    iterator_emit(l);
+  }
+  return NULL;
+}
+
+static int64_t run(int64_t n) {
+  struct range_args args = {
+    .l = 0,
+    .u = n
+  };
+  return mpe_long_voidp(mpe_handle(&iterator_hdef, 
+                                   mpe_voidp_long(0), 
+                                   &range,
+                                   mpe_voidp_ptr(&args)));
+}
+
+int main(int argc, char** argv) { 
+  int64_t n = argc != 2 ? 5 : atoi(argv[1]);
+  int64_t r = run(n);
+
+  // Increase output buffer size to increase performance
+  char buffer[8192];
+  setvbuf(stdout, buffer, _IOFBF, sizeof(buffer));
+  printf("%ld\n", r);
+  return 0;   
+}

--- a/benchmarks/libmpeff/parsing_dollars/main.c
+++ b/benchmarks/libmpeff/parsing_dollars/main.c
@@ -1,0 +1,121 @@
+#include "mpeff.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+MPE_DEFINE_EFFECT1(read, read)
+MPE_DEFINE_OP0(read, read, int)
+
+MPE_DEFINE_EFFECT1(emit, emit)
+MPE_DEFINE_VOIDOP1(emit, emit, long)
+
+MPE_DEFINE_EFFECT1(stop, stop)
+MPE_DEFINE_VOIDOP0(stop, stop)
+
+#define NEWLINE 10
+#define DOLLAR 36
+inline bool is_newline(int c) { return c == NEWLINE; }
+inline bool is_dollar(int c) { return c == DOLLAR; }
+
+// Locals in parse function
+typedef struct parse_locals_t {
+  int64_t i;
+  int64_t j;
+  int64_t n;
+} parse_locals_t;
+
+
+// Sum handler
+static void* sum(mpe_resume_t* r, void* local, void* arg) {
+  int64_t new_s = mpe_long_voidp(local) + mpe_long_voidp(arg);
+  return mpe_resume_tail(r, mpe_voidp_long(new_s), NULL);
+}
+static void* sum_return(void* local, void* arg) {
+  return local;
+}
+static const mpe_handlerdef_t sum_hdef = { 
+  MPE_EFFECT(emit), &sum_return, {
+  { MPE_OP_TAIL_NOOP, MPE_OPTAG(emit,emit), &sum },
+  { MPE_OP_NULL, mpe_op_null, NULL }
+}};
+
+// Read handler
+static void* catch(mpe_resume_t* r, void* local, void* arg) {
+  return NULL;
+}
+static const mpe_handlerdef_t catch_hdef = { 
+  MPE_EFFECT(stop), NULL, {
+  { MPE_OP_NEVER, MPE_OPTAG(stop,stop), &catch },
+  { MPE_OP_FORWARD, MPE_OPTAG(emit,emit), NULL },
+  { MPE_OP_NULL, mpe_op_null, NULL }
+}};
+
+// Feed handler
+static void* feed(mpe_resume_t* r, void* local, void* arg) {
+  parse_locals_t* locals = (parse_locals_t*) local;
+  if (locals->i > locals->n) { 
+    stop_stop();
+    return NULL;
+  }
+  else if (locals->j == 0) {
+    locals->i++;
+    locals->j = locals->i;
+    return mpe_resume_tail(r, local, mpe_voidp_int(NEWLINE));
+  }
+  else {
+    locals->j--;
+    return mpe_resume_tail(r, local, mpe_voidp_int(DOLLAR));
+  }
+}
+static const mpe_handlerdef_t feed_hdef = { 
+  MPE_EFFECT(read), NULL, {
+  { MPE_OP_TAIL, MPE_OPTAG(read,read), &feed },
+  { MPE_OP_FORWARD, MPE_OPTAG(emit,emit), NULL },
+  { MPE_OP_FORWARD, MPE_OPTAG(stop,stop), NULL },
+  { MPE_OP_NULL, mpe_op_null, NULL }
+}};
+
+static void* parse(void* parameter) {
+  int64_t a = 0;
+  while (true) {
+    int c = read_read();
+    if (is_dollar(c)) a++;
+    else if (is_newline(c)) {
+      emit_emit(a);
+      a = 0;
+    }
+    else stop_stop();
+  }
+  return NULL;
+}
+
+static void* run_catch(void* parameter) {
+  parse_locals_t local = {
+    .i = 0,
+    .j = 0,
+    .n = mpe_long_voidp(parameter)
+  };
+  mpe_handle(&feed_hdef, mpe_voidp_ptr(&local), &parse, NULL);
+  return NULL;
+}
+
+static void* run_sum(void* parameter) { 
+  mpe_handle(&catch_hdef, NULL, &run_catch, parameter);
+  return NULL;
+}
+
+static int64_t run(int64_t n) {
+  return mpe_long_voidp(
+    mpe_handle(&sum_hdef, mpe_voidp_long(0), &run_sum, mpe_voidp_long(n))
+  );
+}
+
+int main(int argc, char** argv) { 
+  int64_t n = argc != 2 ? 10 : atoi(argv[1]);
+  int64_t result = run(n);
+
+  // Increase output buffer size to increase performance
+  char buffer[8192];
+  setvbuf(stdout, buffer, _IOFBF, sizeof(buffer));
+  printf("%ld\n", result);
+  return 0; 
+}

--- a/benchmarks/libmpeff/product_early/main.c
+++ b/benchmarks/libmpeff/product_early/main.c
@@ -1,0 +1,85 @@
+#include "mpeff.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+#define ENUMERATE_SIZE 1000
+
+MPE_DEFINE_EFFECT1(early, done);
+MPE_DEFINE_VOIDOP1(early, done, int);
+
+// Using a linked list to mirror the other languages
+typedef struct list {
+  int64_t head;
+  struct list* next;
+} list_t;
+
+static void* handle_early_done(mpe_resume_t* r, void* local, void* arg) {
+  return arg;
+}
+
+static const mpe_handlerdef_t early_hdef = { MPE_EFFECT(early), NULL, {
+  { MPE_OP_NEVER, MPE_OPTAG(early,done), &handle_early_done},
+  { MPE_OP_NULL, mpe_op_null, NULL }
+}};
+
+static void* product(void* parameter) {
+  list_t list = *(list_t*) mpe_ptr_voidp(parameter);
+  if (list.head == 0) {
+    early_done(0);
+    return NULL;
+  }
+  else {
+    int64_t res = mpe_long_voidp(product(mpe_voidp_ptr(list.next))); 
+    return mpe_voidp_long(list.head * res);
+  }
+}
+
+static int run_product(list_t* xs) {
+  return mpe_int_voidp(mpe_handle(&early_hdef, NULL, &product, mpe_voidp_ptr(xs)));
+}
+
+// Allocate a linked list on the heap
+static list_t* enumerate(size_t n) {
+  list_t* top = malloc(sizeof(list_t));
+  list_t* current = top;
+
+  for (size_t i = 0; i < n; i++) {
+    current->head = (n - 1) - i; 
+    if (i == n - 1) current->next = NULL;
+    else current->next = malloc(sizeof(list_t));
+    current = current->next;
+  }
+  return top;
+}
+
+// Free linked list
+static void free_list(list_t* xs) {
+  while (xs != NULL) {
+    list_t* next = xs->next;
+    free(xs);
+    xs = next;
+  }
+}
+
+static int64_t run(int64_t n) {
+  list_t* xs = enumerate(ENUMERATE_SIZE + 1);
+
+  int64_t a = 0;
+  for (int i = 0; i < n; i++) {
+    a += run_product(xs);
+  }
+
+  free_list(xs);
+  return a;
+}
+
+int main(int argc, char** argv) {
+  int64_t n = argc != 2 ? 5 : atoi(argv[1]);
+  int64_t r = run(n);
+
+  // Increase output buffer size to increase performance
+  char buffer[8192];
+  setvbuf(stdout, buffer, _IOFBF, sizeof(buffer));
+  printf("%ld\n", r);
+  return 0;
+}

--- a/benchmarks/libmpeff/resume_nontail/main.c
+++ b/benchmarks/libmpeff/resume_nontail/main.c
@@ -1,0 +1,70 @@
+#include "mpeff.h"
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+MPE_DEFINE_EFFECT1(op, perform)
+MPE_DEFINE_VOIDOP1(op, perform, long)
+
+static inline int64_t binaryOperation(int64_t x, int64_t y) { 
+  return (labs(x - (503 * y) + 37)) % 1009;
+}
+
+static void* handle_op_perform(mpe_resume_t* r, void* local, void* arg) {
+  int64_t result = mpe_long_voidp(mpe_resume(r, local, NULL));
+  return mpe_voidp_long(binaryOperation(mpe_long_voidp(arg), result));
+}
+
+static void* handle_return(void* local, void* arg) {
+  return arg;
+}
+
+static const mpe_handlerdef_t op_hdef = { 
+  MPE_EFFECT(op), &handle_return, {
+  { MPE_OP_SCOPED_ONCE, MPE_OPTAG(op,perform), &handle_op_perform },
+  { MPE_OP_NULL, mpe_op_null, NULL }
+}};
+
+typedef struct loop_args_t {
+  int64_t n;
+  int64_t s;
+} loop_args_t;
+
+// Note: using a for loop instead of recursion because
+// it is the idiomatic way of doing loops in C
+static void* loop(void* parameter) {
+  loop_args_t* args = (loop_args_t*) parameter;
+  for (int i = args->n; i > 0; i--) {
+    op_perform(i);
+  }
+  return (void*) args->s;
+}
+
+static int64_t run(int64_t n, int64_t s) {
+  loop_args_t args = {
+    .n = n,
+    .s = s
+  };
+  return mpe_long_voidp(
+    mpe_handle(&op_hdef, NULL, loop, mpe_voidp_ptr(&args))
+  );
+}
+
+static int64_t repeat(int64_t n) {
+  int64_t s = 0;
+  for (int i = 0; i < 1000; i++) {
+    s = run(n, s);
+  }
+  return s;
+}
+
+int main(int argc, char** argv) { 
+  int64_t n = argc != 2 ? 5 : atoi(argv[1]);
+  int64_t r = repeat(n);
+  
+  // Increase output buffer size to increase performance
+  char buffer[8192];
+  setvbuf(stdout, buffer, _IOFBF, sizeof(buffer));
+  printf("%ld\n", r);
+  return 0; 
+}

--- a/systems/libmpeff/Dockerfile
+++ b/systems/libmpeff/Dockerfile
@@ -30,15 +30,16 @@ RUN wget https://github.com/sharkdp/hyperfine/releases/download/v1.15.0/hyperfin
 RUN sudo dpkg -i hyperfine_1.15.0_amd64.deb
 
 # Install libmprompt/libmpeff
-RUN sudo apt install -y wget git curl gcc make cmake
+RUN sudo apt install -y wget git curl gcc g++ make cmake
 RUN curl -o libmprompt-0.6.3.tar.gz -sL https://github.com/koka-lang/libmprompt/archive/refs/tags/v0.6.3.tar.gz
 RUN tar xvf libmprompt-0.6.3.tar.gz
-WORKDIR ./libmprompt-0.6.3
+RUN mv libmprompt-0.6.3 libmprompt
+WORKDIR ./libmprompt
 
-CMD ["/bin/bash" "mkdir" "-p" "out/release"]
+RUN mkdir -p out/release
 WORKDIR ./out/release
-CMD ["/bin/cmake" "../.."]
-CMD ["/bin/make"]
+RUN cmake "../.." -DMP_USE_C=ON
+RUN make
 
 # Final steps
 ENV DEBIAN_FRONTEND teletype

--- a/systems/libmpeff/Dockerfile
+++ b/systems/libmpeff/Dockerfile
@@ -30,7 +30,7 @@ RUN wget https://github.com/sharkdp/hyperfine/releases/download/v1.15.0/hyperfin
 RUN sudo dpkg -i hyperfine_1.15.0_amd64.deb
 
 # Install libmprompt/libmpeff
-RUN sudo apt install -y wget git curl gcc g++ make cmake
+RUN sudo apt-get update && sudo apt install -y wget git curl make cmake clang-14
 RUN curl -o libmprompt-0.6.3.tar.gz -sL https://github.com/koka-lang/libmprompt/archive/refs/tags/v0.6.3.tar.gz
 RUN tar xvf libmprompt-0.6.3.tar.gz
 RUN mv libmprompt-0.6.3 libmprompt
@@ -38,7 +38,7 @@ WORKDIR ./libmprompt
 
 RUN mkdir -p out/release
 WORKDIR ./out/release
-RUN cmake "../.." -DMP_USE_C=ON
+RUN export CC=/usr/bin/clang-14 && export CXX=/usr/bin/clang++-14 && cmake "../.." -DMP_USE_C=ON -DCMAKE_C_COMPILER=clang-14
 RUN make
 
 # Final steps


### PR DESCRIPTION
I implemented the one-shot benchmarks in `libmpeff` as well, using `clang-14` for ease for comparison to `libseff`:
- countdown
- fibonacci recursive
- product early
- iterator
- generator
- parsing dollars
- resume nontail
- handler sieve

Out of these, I could only get `handler sieve` working by making the `prime()` operation in the handler definition `SCOPED_ONCE`, and then resuming with `mpe_resume_tail` in the handler clause. It takes ~60 seconds when given 60,000 as input, which is substantially longer than any of the other languages. @teofr @dhil maybe you know why? It might have to do with the flags, but if I used `TAIL_NOOP` instead of `SCOPED_ONCE`, the nested handlers would fail to perform the same effect from child to parent.